### PR TITLE
Use absolute links on getting-started.mdx

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -45,6 +45,6 @@ For those wishing to forgo the Git experience
 ![image](..\static\img\getting-started\3.png)
 
 # Resources
-We have provided instructions for creating your first [Avatar](avatars) or [World](worlds) compatible with the Basis framework.
+We have provided instructions for creating your first [Avatar](/docs/avatars) or [World](/docs/worlds) compatible with the Basis framework.
 
 Please join the [Basis Discord](https://discord.gg/F35u3cUMqt) and join a community of developers and hobbyists to help you on your way!


### PR DESCRIPTION
These relative links are broken when accessed from the URL `https://docs.basisvr.org/docs/getting-started/`. They do however work when accessed from `https://docs.basisvr.org/docs/getting-started` (only difference being that final slash). Making the absolute seems to work in both cases.

I couldn't reproduce that issue locally, btw.