### PR TITLE
Update document to point to the non-default "long-term-service" branch

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -34,7 +34,7 @@ Even if you only are only building user generated content for Avatar and World c
 
 # Acquiring the Basis framework
 ## Git
-You can either directly [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the `lts` repository found at https://github.com/BasisVR/Basis or [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) it to your own local repository, and then open the resulting Unity project on your local computer.
+You can either directly [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the `long-term-support` branch found at https://github.com/BasisVR/Basis (i.e. `git clone -b long-term-support https://github.com/BasisVR/Basis`) or [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) it to your own local repository, and then open the resulting Unity project on your local computer.
 
 ## Direct Zip Download
 For those wishing to forgo the Git experience

--- a/docs/server-setup.mdx
+++ b/docs/server-setup.mdx
@@ -30,7 +30,7 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ### Compile and Run on Windows
 
 Assuming you have cloned the LTS branch of the repo.
-`git clone https://github.com/BasisVR/Basis.git`
+`git clone -b long-term-support https://github.com/BasisVR/Basis.git`
 
 You will find the Visual Studio Solution file (sln) in the `Basis Server` directory.
 These steps assume Windows 11 using Microsoft Visual Studio Community 2022 (64-bit) - Version 17.12.3
@@ -91,7 +91,7 @@ Then continue installation:
 
 Change to the folder you wish to download Basis to, and execute the following command:
 
-`git clone https://github.com/BasisVR/Basis`
+`git clone -b long-term-support https://github.com/BasisVR/Basis`
 
 #### Build Basis Server
 


### PR DESCRIPTION
This change was prompted by CI work I'm working on, so I figured I'd better update the documentation to match.