### PR TITLE
fixed: Malformed Markdown

### DIFF
--- a/content/docs/server/configuration.mdx
+++ b/content/docs/server/configuration.mdx
@@ -3,6 +3,7 @@ title: Configuration
 ---
 
 import { Callout } from 'fumadocs-ui/components/callout';
+
 {/*
 ## Introduction 
 
@@ -107,6 +108,7 @@ you first start the client.
 <br />
 <br />
 */}
+
 ### Compile and Run on Linux
 
 #### Prerequisits Assuming Debian/Ubuntu


### PR DESCRIPTION
malformed Markdown (missing space before titles)