### PR TITLE
fix: Update repository links

### DIFF
--- a/content/docs/contributing.mdx
+++ b/content/docs/contributing.mdx
@@ -45,12 +45,12 @@ Standard Markdown is supported, along with extended features:
 
 1. **Fork the Repository**
    
-   Fork the [BasisDocs repository](https://github.com/hactazia/basis-docs) on GitHub.
+   Fork the [BasisDocs repository](https://github.com/hactazia/) on GitHub.
 
 2. **Clone Your Fork**
    
    ```bash
-   git clone https://github.com/YOUR_USERNAME/basis-docs.git
+   git clone https://github.com/YOUR_USERNAME/.git
    cd basis-docs
    ```
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,7 +6,6 @@ const withMDX = createMDX();
 const config = {
   reactStrictMode: true,
   output: 'export',
-  basePath: '/basis-docs',
   images: {
     unoptimized: true,
   },

--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -8,7 +8,7 @@ export function baseOptions(): BaseLayoutProps {
         <div className="flex items-center gap-2">
           <Image
             id="logo"
-            src="/basis-docs/img/BasisLogoSmall.png"
+            src="/img/BasisLogoSmall.png"
             alt="BasisVR Logo"
             width={32}
             height={32}


### PR DESCRIPTION
You have a custom domain name, so it wasn't compatible. 
This time it should be fine.