### PR TITLE
Adding build times for avatar likely.

### DIFF
--- a/content/docs/avatar/building.mdx
+++ b/content/docs/avatar/building.mdx
@@ -25,7 +25,7 @@ Basis uses the .BEE file extension, which contains your compiled asset and meta 
 The .BEE file, along with a randomly generated password to access it, is created under your Unity Project path /AssetBundles/ directory and is hidden from Unity by default.
 </Callout>
 
-- Each platform takes on average 2 minutes from cold/no cache build. Building for all platforms will take some time. Likely more than 10 minutes for all platforms.
+- Each platform takes on average 2 minutes from cold/no cache build. Building for all platforms will take some time. Likely more than 10 minutes for all platforms. Hot build/cached took little over 2 mins on same avatar and specs.
 
 <Callout type="info">
 An avatar with 18 materials using Poiyomi URP with 120K polygons, with package size 45MB per platform, took 9m 43s on a Ryzen 7 9800x3D. Jan, 2026


### PR DESCRIPTION
Wanted to add into the docs how long it on average it takes to build for each platform on a high end machine.
Might later use my sister computer to see on modest i5 cpu takes.