### PR TITLE
Fix Missing Icon in tab.

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,7 @@ export const metadata: Metadata = {
     images: ['/img/basisvr-social-card.jpg'],
   },
   icons: {
-    icon: '/img/favicon.ico',
+    icon: '/img/BasisLogoSmall.png',
   },
 };
 


### PR DESCRIPTION
We didn't specify the basis logo for favicon location.