### PR TITLE
feat: add i18n support for 8 languages

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,6 +1,0 @@
-import { HomeLayout } from 'fumadocs-ui/layouts/home';
-import { baseOptions } from '@/lib/layout.shared';
-
-export default function Layout({ children }: LayoutProps<'/'>) {
-  return <HomeLayout {...baseOptions()}>{children}</HomeLayout>;
-}

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function HomePage() {
-  redirect('/docs');
-}

--- a/src/app/[lang]/(home)/layout.tsx
+++ b/src/app/[lang]/(home)/layout.tsx
@@ -1,0 +1,14 @@
+import { HomeLayout } from 'fumadocs-ui/layouts/home';
+import { baseOptions } from '@/lib/layout.shared';
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+
+  return <HomeLayout {...baseOptions(lang)}>{children}</HomeLayout>;
+}

--- a/src/app/[lang]/(home)/page.tsx
+++ b/src/app/[lang]/(home)/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from 'next/navigation';
+
+export default async function HomePage({
+  params,
+}: {
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+  redirect(`/${lang}/docs`);
+}

--- a/src/app/[lang]/docs/[[...slug]]/page.tsx
+++ b/src/app/[lang]/docs/[[...slug]]/page.tsx
@@ -9,18 +9,21 @@ import { notFound } from 'next/navigation';
 import { getMDXComponents } from '@/mdx-components';
 import type { Metadata } from 'next';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
+import { i18n } from '@/lib/i18n';
 
-export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
+export default async function Page(props: {
+  params: Promise<{ lang: string; slug?: string[] }>;
+}) {
   const params = await props.params;
-  const page = source.getPage(params.slug);
+  const page = source.getPage(params.slug, params.lang);
   if (!page) notFound();
 
   const MDX = page.data.body;
   const path = `content/docs/${params.slug?.join('/') || 'index'}.mdx`;
 
   return (
-    <DocsPage 
-      toc={page.data.toc} 
+    <DocsPage
+      toc={page.data.toc}
       full={page.data.full}
       editOnGithub={{
         owner: 'BasisVR',
@@ -34,7 +37,6 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
       <DocsBody>
         <MDX
           components={getMDXComponents({
-            // this allows you to link to other pages with relative file paths
             a: createRelativeLink(source, page),
           })}
         />
@@ -43,15 +45,20 @@ export default async function Page(props: PageProps<'/docs/[[...slug]]'>) {
   );
 }
 
-export async function generateStaticParams() {
-  return source.generateParams();
+export function generateStaticParams() {
+  return i18n.languages.flatMap((lang) =>
+    source.getPages(lang).map((page) => ({
+      lang,
+      slug: page.slugs,
+    })),
+  );
 }
 
-export async function generateMetadata(
-  props: PageProps<'/docs/[[...slug]]'>,
-): Promise<Metadata> {
+export async function generateMetadata(props: {
+  params: Promise<{ lang: string; slug?: string[] }>;
+}): Promise<Metadata> {
   const params = await props.params;
-  const page = source.getPage(params.slug);
+  const page = source.getPage(params.slug, params.lang);
   if (!page) notFound();
 
   return {

--- a/src/app/[lang]/docs/layout.tsx
+++ b/src/app/[lang]/docs/layout.tsx
@@ -3,11 +3,19 @@ import { DocsLayout } from 'fumadocs-ui/layouts/notebook';
 import { baseOptions } from '@/lib/layout.shared';
 import type { ReactNode } from 'react';
 
-export default function Layout({ children }: { children: ReactNode }) {
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: ReactNode;
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+
   return (
-    <DocsLayout 
-      tree={source.pageTree} 
-      {...baseOptions()}
+    <DocsLayout
+      tree={source.pageTree[lang]}
+      {...baseOptions(lang)}
       sidebar={{
         defaultOpenLevel: 0,
         footer: (

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,0 +1,71 @@
+import { RootProvider } from 'fumadocs-ui/provider/next';
+import type { Metadata } from 'next';
+import { i18n, localeDisplayNames } from '@/lib/i18n';
+
+export const metadata: Metadata = {
+  title: {
+    default: 'BasisVR Docs',
+    template: '%s | BasisVR Docs',
+  },
+  description: 'Documentation for BasisVR - Virtual Reality Framework',
+  metadataBase: new URL('https://docs.basisvr.org'),
+  openGraph: {
+    title: 'BasisVR Docs',
+    description: 'Documentation for BasisVR - Virtual Reality Framework',
+    url: 'https://docs.basisvr.org',
+    siteName: 'BasisVR Docs',
+    images: [
+      {
+        url: '/img/basisvr-social-card.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'BasisVR',
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'BasisVR Docs',
+    description: 'Documentation for BasisVR - Virtual Reality Framework',
+    images: ['/img/basisvr-social-card.jpg'],
+  },
+  icons: {
+    icon: '/img/BasisLogoSmall.png',
+  },
+};
+
+export default async function LangLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ lang: string }>;
+}) {
+  const { lang } = await params;
+
+  return (
+    <RootProvider
+      locale={lang}
+      i18n={{
+        locale: lang,
+        locales: i18n.languages.map((l) => ({
+          locale: l,
+          name: localeDisplayNames[l] ?? l,
+        })),
+      }}
+      search={{
+        enabled: false,
+      }}
+      theme={{
+        defaultTheme: 'dark',
+      }}
+    >
+      {children}
+    </RootProvider>
+  );
+}
+
+export function generateStaticParams() {
+  return i18n.languages.map((lang) => ({ lang }));
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,61 +1,18 @@
-import { RootProvider } from 'fumadocs-ui/provider/next';
-import type { Metadata } from 'next';
 import './global.css';
 import { Inter } from 'next/font/google';
 
 const inter = Inter({
-  subsets: ['latin'],
+  subsets: ['latin', 'latin-ext', 'cyrillic'],
 });
 
-export const metadata: Metadata = {
-  title: {
-    default: 'BasisVR Docs',
-    template: '%s | BasisVR Docs',
-  },
-  description: 'Documentation for BasisVR - Virtual Reality Framework',
-  metadataBase: new URL('https://docs.basisvr.org'),
-  openGraph: {
-    title: 'BasisVR Docs',
-    description: 'Documentation for BasisVR - Virtual Reality Framework',
-    url: 'https://docs.basisvr.org',
-    siteName: 'BasisVR Docs',
-    images: [
-      {
-        url: '/img/basisvr-social-card.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'BasisVR',
-      },
-    ],
-    locale: 'en',
-    type: 'website',
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'BasisVR Docs',
-    description: 'Documentation for BasisVR - Virtual Reality Framework',
-    images: ['/img/basisvr-social-card.jpg'],
-  },
-  icons: {
-    icon: '/img/BasisLogoSmall.png',
-  },
-};
-
-export default function Layout({ children }: LayoutProps<'/'>) {
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   return (
-    <html lang="en" className={inter.className} suppressHydrationWarning>
-      <body className="flex flex-col min-h-screen">
-        <RootProvider
-          search={{
-            enabled: false,
-          }}
-          theme={{
-            defaultTheme: 'dark',
-          }}
-        >
-          {children}
-        </RootProvider>
-      </body>
+    <html suppressHydrationWarning className={inter.className}>
+      <body className="flex flex-col min-h-screen">{children}</body>
     </html>
   );
 }

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -3,7 +3,7 @@ import { getLLMText, source } from '@/lib/source';
 export const revalidate = false;
 
 export async function GET() {
-  const scan = source.getPages().map(getLLMText);
+  const scan = source.getPages('en').map(getLLMText);
   const scanned = await Promise.all(scan);
 
   return new Response(scanned.join('\n\n'));

--- a/src/app/og/docs/[...slug]/route.tsx
+++ b/src/app/og/docs/[...slug]/route.tsx
@@ -2,6 +2,7 @@ import { getPageImage, source } from '@/lib/source';
 import { notFound } from 'next/navigation';
 import { ImageResponse } from 'next/og';
 import { generate as DefaultImage } from 'fumadocs-ui/og';
+import { i18n } from '@/lib/i18n';
 
 export const revalidate = false;
 
@@ -28,8 +29,9 @@ export async function GET(
 }
 
 export function generateStaticParams() {
-  return source.getPages().map((page) => ({
-    lang: page.locale,
-    slug: getPageImage(page).segments,
-  }));
+  return i18n.languages.flatMap((lang) =>
+    source.getPages(lang).map((page) => ({
+      slug: getPageImage(page).segments,
+    })),
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function RootPage() {
+  redirect('/en');
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,17 @@
+import { defineI18n } from 'fumadocs-core/i18n';
+
+export const i18n = defineI18n({
+  defaultLanguage: 'en',
+  languages: ['en', 'fr', 'de', 'es', 'ja', 'ru', 'cn', 'tw'],
+});
+
+export const localeDisplayNames: Record<string, string> = {
+  en: 'English',
+  fr: 'Français',
+  de: 'Deutsch',
+  es: 'Español',
+  ja: '日本語',
+  ru: 'Русский',
+  cn: '简体中文',
+  tw: '繁體中文',
+};

--- a/src/lib/layout.shared.tsx
+++ b/src/lib/layout.shared.tsx
@@ -1,7 +1,7 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 import Image from 'next/image';
 
-export function baseOptions(): BaseLayoutProps {
+export function baseOptions(lang: string = 'en'): BaseLayoutProps {
   return {
     nav: {
       title: (
@@ -22,7 +22,7 @@ export function baseOptions(): BaseLayoutProps {
     links: [
       {
         text: 'Pages',
-        url: '/docs',
+        url: `/${lang}/docs`,
         active: 'nested-url',
       },
       {

--- a/src/lib/source.ts
+++ b/src/lib/source.ts
@@ -1,11 +1,13 @@
 import { docs } from '@/.source';
 import { type InferPageType, loader } from 'fumadocs-core/source';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
+import { i18n } from '@/lib/i18n';
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
+  i18n,
   plugins: [lucideIconsPlugin()],
 });
 


### PR DESCRIPTION
## Summary                                                                                                                                                 
                                                 
  - Add internationalization (i18n) infrastructure using Fumadocs `defineI18n` with support for 8 languages: English, French, German, Spanish, Japanese,     
  Russian, Simplified Chinese, and Traditional Chinese                                                                                                       
  - Restructure app routes under a `[lang]` dynamic segment for locale-aware routing                                                                         
  - Existing English content serves as fallback when translations don't exist

  ## Changes

  - `src/lib/i18n.ts` — i18n config with locale definitions and display names
  - `src/lib/source.ts` — pass i18n config to Fumadocs source loader
  - `src/app/[lang]/` — locale-aware layouts and pages (root, home, docs)
  - `src/app/layout.tsx` — simplified to font/styles only, added cyrillic subset
  - `src/app/page.tsx` — root redirect from `/` to `/en`
  - `src/lib/layout.shared.tsx` — locale-aware navigation URLs
  - LLM and OG image routes updated for locale support

  ## Adding translated content

  Use the Fumadocs dot convention to add translations:
  - `content/docs/index.fr.mdx` — French version of a page
  - `content/docs/meta.fr.json` — French sidebar metadata
  - Locale codes: `en`, `fr`, `de`, `es`, `ja`, `ru`, `cn`, `tw`