### PR TITLE
Added links to docker and docker compose pages

### DIFF
--- a/content/docs/server/deployment.cn.mdx
+++ b/content/docs/server/deployment.cn.mdx
@@ -22,9 +22,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## 使用 Docker 运行
+## 使用 [Docker](https://docs.docker.com/get-started/docker-overview/) 运行
 
-使用 docker-compose 是启动 Basis 服务器最简单快捷的方式。服务器的 Docker 镜像在 GitHub 上同时发布在 `long-term-support` 和 `developer` 分支，分别以 `latest` 和 `nightly` 标识。
+使用 [docker-compose](https://docs.docker.com/compose/) 是启动 Basis 服务器最简单快捷的方式。服务器的 Docker 镜像在 GitHub 上同时发布在 `long-term-support` 和 `developer` 分支，分别以 `latest` 和 `nightly` 标识。
 
 ```yml
 services:

--- a/content/docs/server/deployment.de.mdx
+++ b/content/docs/server/deployment.de.mdx
@@ -22,9 +22,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## Mit Docker ausführen
+## Mit [Docker](https://docs.docker.com/get-started/docker-overview/) ausführen
 
-Die Verwendung von docker-compose ist der einfachste und schnellste Weg, einen Basis-Server zu starten. Docker-Images des Servers werden auf GitHub sowohl für den `long-term-support`- als auch den `developer`-Branch unter `latest` bzw. `nightly` veröffentlicht.
+Die Verwendung von [docker-compose](https://docs.docker.com/compose/) ist der einfachste und schnellste Weg, einen Basis-Server zu starten. Docker-Images des Servers werden auf GitHub sowohl für den `long-term-support`- als auch den `developer`-Branch unter `latest` bzw. `nightly` veröffentlicht.
 
 ```yml
 services:

--- a/content/docs/server/deployment.es.mdx
+++ b/content/docs/server/deployment.es.mdx
@@ -22,9 +22,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## Ejecutar con Docker
+## Ejecutar con [Docker](https://docs.docker.com/get-started/docker-overview/)
 
-Usar docker-compose es la forma más fácil y rápida de poner en marcha un servidor Basis. Las imágenes Docker del servidor se publican en GitHub tanto en las ramas `long-term-support` como `developer`, bajo `latest` y `nightly` respectivamente.
+Usar [docker-compose](https://docs.docker.com/compose/) es la forma más fácil y rápida de poner en marcha un servidor Basis. Las imágenes Docker del servidor se publican en GitHub tanto en las ramas `long-term-support` como `developer`, bajo `latest` y `nightly` respectivamente.
 
 ```yml
 services:

--- a/content/docs/server/deployment.fr.mdx
+++ b/content/docs/server/deployment.fr.mdx
@@ -22,9 +22,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## Exécuter avec Docker
+## Exécuter avec [Docker](https://docs.docker.com/get-started/docker-overview/)
 
-Utiliser docker-compose est le moyen le plus simple et le plus rapide de démarrer un serveur Basis. Les images Docker du serveur sont publiées sur GitHub sur les branches `long-term-support` et `developer`, sous `latest` et `nightly` respectivement.
+Utiliser [docker-compose](https://docs.docker.com/compose/) est le moyen le plus simple et le plus rapide de démarrer un serveur Basis. Les images Docker du serveur sont publiées sur GitHub sur les branches `long-term-support` et `developer`, sous `latest` et `nightly` respectivement.
 
 ```yml
 services:

--- a/content/docs/server/deployment.it.mdx
+++ b/content/docs/server/deployment.it.mdx
@@ -22,9 +22,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## Esecuzione con Docker
+## Esecuzione con [Docker](https://docs.docker.com/get-started/docker-overview/)
 
-L'utilizzo di docker-compose è il modo più semplice e veloce per avviare un server Basis. Le immagini Docker del server vengono pubblicate su GitHub sia nel branch `long-term-support` che nel branch `developer`, rispettivamente con i tag `latest` e `nightly`.
+L'utilizzo di [docker-compose](https://docs.docker.com/compose/) è il modo più semplice e veloce per avviare un server Basis. Le immagini Docker del server vengono pubblicate su GitHub sia nel branch `long-term-support` che nel branch `developer`, rispettivamente con i tag `latest` e `nightly`.
 
 ```yml
 services:

--- a/content/docs/server/deployment.ja.mdx
+++ b/content/docs/server/deployment.ja.mdx
@@ -22,9 +22,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## Dockerで実行する
+## [Docker](https://docs.docker.com/get-started/docker-overview/)で実行する
 
-docker-composeを使用するのが、Basisサーバーを起動する最も簡単で速い方法です。サーバーのDockerイメージはGitHubに`long-term-support`と`developer`ブランチの両方で、それぞれ`latest`と`nightly`として公開されています。
+[docker-compose](https://docs.docker.com/compose/)を使用するのが、Basisサーバーを起動する最も簡単で速い方法です。サーバーのDockerイメージはGitHubに`long-term-support`と`developer`ブランチの両方で、それぞれ`latest`と`nightly`として公開されています。
 
 ```yml
 services:

--- a/content/docs/server/deployment.ko.mdx
+++ b/content/docs/server/deployment.ko.mdx
@@ -22,9 +22,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## Docker로 실행
+## [Docker](https://docs.docker.com/get-started/docker-overview/)로 실행
 
-docker-compose를 사용하는 것이 Basis 서버를 시작하는 가장 쉽고 빠른 방법입니다. 서버의 Docker 이미지는 `long-term-support`와 `developer` 브랜치 모두 GitHub에 각각 `latest`와 `nightly`로 게시됩니다.
+[docker-compose](https://docs.docker.com/compose/)를 사용하는 것이 Basis 서버를 시작하는 가장 쉽고 빠른 방법입니다. 서버의 Docker 이미지는 `long-term-support`와 `developer` 브랜치 모두 GitHub에 각각 `latest`와 `nightly`로 게시됩니다.
 
 ```yml
 services:

--- a/content/docs/server/deployment.mdx
+++ b/content/docs/server/deployment.mdx
@@ -25,9 +25,9 @@ BasisNetworkCore\BasisNetworkVersion.cs
 ```
 </Callout>
 
-## Run with Docker
+## Run with [Docker](https://docs.docker.com/get-started/docker-overview/)
 
-Using docker-compose is the easiest and fastest way to spin up a Basis server. Docker images of the server are published to github on both `long-term-support` and `developer` branches, under `latest` and `nightly` respectively.
+Using [docker-compose](https://docs.docker.com/compose/) is the easiest and fastest way to spin up a Basis server. Docker images of the server are published to github on both `long-term-support` and `developer` branches, under `latest` and `nightly` respectively.
 
 ```yml
 services:


### PR DESCRIPTION
Not everyone coming across the page has used docker before and thought it would be useful if it linked out to the documentation.

- The docker get start page was chosen because if it is someone's first time with docker it provides the best introduction (the main site docker.com is much less help to find a getting start guide).
- Docker-compose links to the docker compose docs.

I could not find if the docs are also in a translated format. After searching and asking their chatbot it appears they are not else I would link each translation to their language.