### PR TITLE
feat: add locale switcher with client-side navigation

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -1,6 +1,6 @@
-import { RootProvider } from 'fumadocs-ui/provider/next';
 import type { Metadata } from 'next';
 import { i18n, localeDisplayNames } from '@/lib/i18n';
+import { LocaleProvider } from '@/components/LocaleProvider';
 
 export const metadata: Metadata = {
   title: {
@@ -44,24 +44,15 @@ export default async function LangLayout({
 }) {
   const { lang } = await params;
 
+  const locales = i18n.languages.map((l) => ({
+    locale: l,
+    name: localeDisplayNames[l] ?? l,
+  }));
+
   return (
-    <RootProvider
-      i18n={{
-        locale: lang,
-        locales: i18n.languages.map((l) => ({
-          locale: l,
-          name: localeDisplayNames[l] ?? l,
-        })),
-      }}
-      search={{
-        enabled: false,
-      }}
-      theme={{
-        defaultTheme: 'dark',
-      }}
-    >
+    <LocaleProvider lang={lang} locales={locales}>
       {children}
-    </RootProvider>
+    </LocaleProvider>
   );
 }
 

--- a/src/components/LocaleProvider.tsx
+++ b/src/components/LocaleProvider.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { RootProvider } from 'fumadocs-ui/provider/next';
+import { useRouter, usePathname } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+interface LocaleProviderProps {
+  lang: string;
+  locales: { locale: string; name: string }[];
+  children: ReactNode;
+}
+
+export function LocaleProvider({ lang, locales, children }: LocaleProviderProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+
+  function onLocaleChange(locale: string) {
+    const segments = pathname.split('/');
+    segments[1] = locale;
+    router.push(segments.join('/'));
+  }
+
+  return (
+    <RootProvider
+      i18n={{ locale: lang, locales, onChange: onLocaleChange }}
+      search={{ enabled: false }}
+      theme={{ defaultTheme: 'dark' }}
+    >
+      {children}
+    </RootProvider>
+  );
+}


### PR DESCRIPTION
## Summary                                                                                      
                                                                                                  
  - Adds a `LocaleProvider` client component that wraps `RootProvider` with an `onChange` handler 
  for locale switching                                                                            
  - When a user selects a locale from Fumadocs' built-in language switcher, the handler replaces
  the locale segment in the current path and navigates (e.g. `/en/docs/page` → `/fr/docs/page`)
  - `layout.tsx` updated to use `LocaleProvider`, keeping all existing search and theme settings
  intact