### PR TITLE
docs: fill open documentation gaps (controls, tracking, networking, features)

### DIFF
--- a/content/docs/avatar/animation-recorder.mdx
+++ b/content/docs/avatar/animation-recorder.mdx
@@ -1,0 +1,35 @@
+---
+title: Animation Recorder
+description: Record your local avatar's motion to a file from the Basis client's developer settings.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Overview
+
+The **Animation Recorder** captures your local avatar's motion frame by frame and writes it to a file. It records the avatar's root position and rotation, its full humanoid muscle pose, and its scale — everything needed to reproduce the body's movement.
+
+<Callout type="info">
+Recording uses Unity's humanoid pose system, so it only works with a **humanoid** avatar.
+</Callout>
+
+## Recording
+
+The recorder lives in **Settings → Developer → Recorder**.
+
+1. Open **Settings → Developer** and find the **Recorder** section.
+2. Set the **countdown** — how long the recorder waits before it starts capturing, giving you time to get into position. Set it to `0` to start immediately.
+3. Optionally enable **auto-stop** and set a **maximum duration** to cap the recording length automatically.
+4. Press **Start**. The status shows the countdown, then the elapsed time and frame count while recording.
+5. Press **Stop** when you're done (or let auto-stop end it).
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/avatars/animation-recorder.png
+    Show:  the Settings → Developer → Recorder panel mid-recording, with the countdown/elapsed time and frame count visible.
+    When ready, replace this comment with:
+    ![The animation recorder in the developer settings](/img/avatars/animation-recorder.png)
+*/}
+
+## Where recordings are saved
+
+Each recording is written to an `AvatarRecordings` folder inside your local Basis data folder, with a timestamped filename. The file is a compact binary capture of every frame — the interval since the previous frame, the root rotation and position, the humanoid muscle values and the avatar scale.

--- a/content/docs/avatar/face-tracking.mdx
+++ b/content/docs/avatar/face-tracking.mdx
@@ -1,6 +1,38 @@
 ---
 title: Face Tracking
+description: Setting up face and eye tracking on a Basis avatar — the components and avatar fields involved, and the full step-by-step guide.
 ---
 
-- Hai has created a comprehensive guide on how to add the Automatic Face Tracking component to an avatar in a Basis project
-- You can follow the link [here](https://docs.hai-vr.dev/docs/basis/avatar-customization/face-tracking) for instruction on how this works.
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Overview
+
+Basis can drive an avatar's facial expressions and eyes from a face tracker. It does this with **blendshapes** for expressions and visemes, and by rotating the avatar's **eye bones** for gaze. Much of the wiring is automatic: when an avatar loads, Basis detects the blendshape naming convention on the mesh (Unified Expressions or ARKit) and attaches the components that map incoming face-tracking values onto it.
+
+<Callout type="info">
+Hai maintains the comprehensive step-by-step guide for adding the Automatic Face Tracking component to an avatar. Follow it for the full setup: [Face tracking on docs.hai-vr.dev](https://docs.hai-vr.dev/docs/basis/avatar-customization/face-tracking).
+</Callout>
+
+## What gets set up on the avatar
+
+The guide above walks through the process; this is what it's configuring under the hood, so you know what each piece is for.
+
+- **Viseme / expression blendshapes** — your avatar's face mesh and the blendshape indices Basis drives for mouth shapes and expressions. These are picked up from the mesh's blendshape names.
+- **Blink** — the mesh and blendshape used to blink. Basis auto-blinks the avatar when no external face tracker is overriding the eyes.
+- **Eye bones** — the avatar's left and right eye bones. Basis calibrates each eye's local axes on load so gaze rotates correctly regardless of how the bones are oriented in the rig.
+
+When face tracking is connected, incoming expression values are mapped onto the blendshapes and the eye angles drive the eye bones. When it isn't, the avatar falls back to automatic blinking and look-at-target gaze, so faces still feel alive without a tracker.
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/avatars/face-tracking-setup.png
+    Show:  the Automatic Face Tracking component on an avatar in the Inspector, with the face/eye fields populated.
+    When ready, replace this comment with:
+    ![Face tracking components set up on an avatar](/img/avatars/face-tracking-setup.png)
+*/}
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/avatars/face-tracking-result.png
+    Show:  an avatar in-client mirroring the wearer's expression and eye gaze from a face tracker.
+    When ready, replace this comment with:
+    ![An avatar's face driven by a face tracker](/img/avatars/face-tracking-result.png)
+*/}

--- a/content/docs/avatar/meta.json
+++ b/content/docs/avatar/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Avatar",
   "icon": "User",
-  "pages": ["index", "setup", "building", "uploading", "jiggle", "authored-motion", "animation-rigging", "face-tracking", "shaders"]
+  "pages": ["index", "setup", "building", "uploading", "jiggle", "authored-motion", "animation-rigging", "face-tracking", "animation-recorder", "shaders"]
 }

--- a/content/docs/controls/chatbox.mdx
+++ b/content/docs/controls/chatbox.mdx
@@ -1,0 +1,37 @@
+---
+title: Chatbox
+description: Sending text chat in Basis, the typing indicator, and the OSC bridge for driving the chatbox from external apps.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Overview
+
+The chatbox lets you send short text messages that appear above your avatar for everyone nearby to read — useful when voice isn't an option. Open it with the **Open Chat** key (`Y` by default — see [Settings and Controls](/en/docs/controls)), type a message and send.
+
+- Messages can be up to **256 characters**.
+- A sent message shows above your avatar for about **10 seconds**, then clears.
+- While you're typing, others see a **typing indicator** over your avatar, so they know a message is coming.
+- An optional notification sound can play when a message arrives.
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/controls/chatbox.png
+    Show:  a chat message displayed above an avatar in-client, ideally with another avatar's typing indicator visible.
+    When ready, replace this comment with:
+    ![A chatbox message shown above an avatar](/img/controls/chatbox.png)
+*/}
+
+<Callout type="info">
+You can hide an individual player's chat messages from their [player panel](/en/docs/controls/players-menu).
+</Callout>
+
+## Driving the chatbox over OSC
+
+The chatbox can also be controlled from an external application over **OSC**, on the address `/chatbox/input`. This lets tools type into the chatbox for you — for example a speech-to-text app or a status display.
+
+The address accepts:
+
+- A single **bool** — sets the typing indicator on or off without sending anything.
+- A **string** with two optional bools — `(text, openKeyboard, playNotificationSound)`. The text is the message; the first bool chooses whether to open the in-client composer or send straight away; the second chooses whether a notification sound plays.
+
+Text coming in over OSC is sanitised the same way as text typed in-client. See [OSC](/en/docs/scripting/osc) for enabling and configuring the OSC connection.

--- a/content/docs/controls/full-body-tracking.mdx
+++ b/content/docs/controls/full-body-tracking.mdx
@@ -1,0 +1,61 @@
+---
+title: Full Body Tracking
+description: How Basis assigns and calibrates SteamVR / OpenXR trackers to your body for full body tracking, plus pairing and manual role overrides.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Overview
+
+Full body tracking (FBT) lets Basis drive your avatar's hips, feet and limbs from physical trackers rather than estimating them from your head and hands alone. Basis reads trackers through **OpenXR** (including the HTC Vive tracker profile), and works out which tracker belongs on which part of your body automatically from a single calibration pose.
+
+The roles Basis can assign a tracker to are:
+
+- **Hips** and **Chest**
+- **Left / Right Foot** and **Left / Right Toes**
+- **Left / Right Lower Leg** (shins)
+- **Left / Right Shoulder**
+- **Left / Right Lower Arm** (forearms)
+
+## Calibrating
+
+Basis uses **constellation calibration**: you stand in a T-pose and it classifies each free tracker by where it sits in space relative to your headset, then assigns it to the closest matching body role.
+
+1. Put on your headset and trackers and make sure each tracker is tracking.
+2. Open the tracker calibration option in **Settings**.
+3. Stand in a **T-pose** — feet roughly shoulder-width apart, arms straight out to the sides.
+4. Trigger calibration and hold the pose until it completes.
+
+Your avatar is put into a reference T-pose during calibration, the trackers are classified, and the FBT roles bind to your avatar's bones.
+
+<Callout type="info">
+Calibration is geometry-based, so a clean T-pose matters. If a tracker ends up on the wrong limb, re-run calibration with a more deliberate pose, or pin that tracker to a role with an override (below).
+</Callout>
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/controls/fbt-calibration.png
+    Show:  a user in a T-pose with the tracker calibration prompt visible in-client.
+    When ready, replace this comment with:
+    ![Calibrating full body trackers in a T-pose](/img/controls/fbt-calibration.png)
+*/}
+
+## Tracker pairing
+
+Symmetrical tracker setups (for example a pair of ankle trackers) can be **paired** so Basis treats them as a linked set during classification. Pairings are saved to disk and reused, so you don't have to re-pair them every session.
+
+## Manual role overrides
+
+If the automatic classifier keeps misassigning a particular tracker — common with unusual mounting positions — you can **force a tracker to a specific role**. An override skips the scoring step for that tracker and assigns it directly, so the rest of the constellation still calibrates around it.
+
+Like pairings, overrides persist between sessions, so a setup you've tuned once keeps working on the next launch with the same trackers.
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/controls/fbt-role-override.png
+    Show:  the tracker role override UI with a tracker assigned to a specific body role.
+    When ready, replace this comment with:
+    ![Assigning a tracker to a fixed role](/img/controls/fbt-role-override.png)
+*/}
+
+<Callout type="info">
+Pairings and overrides are stored in your local Basis data folder, alongside the other per-user files documented in [Settings and Controls](/en/docs/controls). Deleting them resets you to fully automatic classification.
+</Callout>

--- a/content/docs/controls/hand-tracking.mdx
+++ b/content/docs/controls/hand-tracking.mdx
@@ -1,0 +1,34 @@
+---
+title: Hand Tracking
+description: Articulated hand and finger tracking in Basis through OpenXR, and how it falls back to controller input when a hand isn't tracked.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Overview
+
+Basis supports **articulated hand tracking** through OpenXR, so your avatar's fingers follow your real hands on runtimes that expose hand tracking — such as Quest's camera-based tracking or a PC OpenXR runtime that provides it. No per-avatar setup is needed: hand tracking drives the same finger pose system that controllers do.
+
+## What gets tracked
+
+For each hand, Basis reads the wrist pose and the curl and spread of all five fingers:
+
+- **Curl** — how far each finger is bent, from open to a full fist.
+- **Spread** — how far the fingers are splayed apart.
+
+These feed your avatar's hand pose every frame, blended smoothly so finger motion looks natural rather than snapping between poses.
+
+## Controllers and fallback
+
+Hand tracking and controllers share one pose pipeline, so you can switch between them without any change in setup. When a hand isn't being optically tracked — you're holding controllers, or a hand leaves the tracking volume — Basis falls back to driving the fingers from the controller's **trigger and grip** instead, so your avatar's hands still close around grips and respond to input.
+
+<Callout type="info">
+Hand tracking availability depends on your headset and OpenXR runtime. On Quest, enable hand tracking in the headset's system settings; Basis picks it up automatically when the runtime reports it.
+</Callout>
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/controls/hand-tracking.png
+    Show:  an avatar's articulated hands following real finger movement in-client.
+    When ready, replace this comment with:
+    ![Articulated hand tracking driving an avatar's fingers](/img/controls/hand-tracking.png)
+*/}

--- a/content/docs/controls/index.mdx
+++ b/content/docs/controls/index.mdx
@@ -1,19 +1,83 @@
 ---
 title: Settings and Controls
+description: Default keyboard, mouse and VR controller bindings for the Basis client, where to rebind them, and where to find logs and library data.
 ---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 ## Controls
 
-Let's create a page to cover the available controls in BasisVR
+Basis has a fuller set of controls than most people realise on first launch. This page is a quick reference for the defaults across desktop and VR, and where to change them.
 
+<Callout type="info">
+Every keyboard binding below is **rebindable** in-client under **Settings → Keyboard Bindings**. The button for each control shows its current key, and the default in brackets if you've changed it. **Escape** cancels a rebind in progress, and you can reset everything back to defaults from the same panel.
+</Callout>
 
-## Keyboard Shortcuts
+{/* IMAGE PLACEHOLDER
+    File:  public/img/controls/keyboard-bindings.png
+    Show:  the in-client Settings → Keyboard Bindings panel with the grouped, rebindable controls visible.
+    When ready, replace this comment with:
+    ![The Keyboard Bindings settings panel](/img/controls/keyboard-bindings.png)
+*/}
 
-- F9: switch to Desktop
+### Movement
 
-- F10: switch to OpenXR
+| Action | Default key |
+| --- | --- |
+| Forward / Back / Left / Right | `W` `S` `A` `D` |
+| Movement (alternative) | Arrow keys |
+| Jump | `Space` |
+| Sprint | `Left Shift` |
+| Crouch | `C` |
+| Fly up / down | `R` / `F` |
 
-- F11: Switch to OpenVR
+### Camera (desktop)
+
+| Action | Default |
+| --- | --- |
+| Look | Move the mouse |
+| Look (keyboard alternative) | `I` `K` `J` `L` (and `,` `.`) |
+| Toggle third-person view | `F` |
+| Zoom (in third-person) | Mouse scroll wheel |
+| Interact / select | Left mouse button |
+
+### Communication and menus
+
+| Action | Default key |
+| --- | --- |
+| Toggle microphone | `V` |
+| Open chat | `Y` |
+| Free cursor (unlock mouse for UI) | `Tab` |
+| Open / close menu | `Escape` |
+
+<Callout type="info">
+**Toggle microphone** depends on your microphone mode. With push-to-talk, `V` transmits while held; in toggle mode it switches the mic on and off. Set the mode in the audio settings.
+</Callout>
+
+### Switching input mode
+
+You can move between desktop and the two XR runtimes at runtime:
+
+| Key | Mode |
+| --- | --- |
+| `F9` | Desktop |
+| `F10` | OpenXR |
+| `F11` | OpenVR |
+
+### VR controllers
+
+In VR the same actions map to the controllers rather than the keyboard:
+
+- **Thumbstick** — movement (one controller) and turning (the other).
+- **Trigger** — interact / select, the controller equivalent of left mouse button.
+- **Grip** — used for descending in fly mode and for grabbing.
+- **Primary face button** — jump.
+- **Menu / system button** — opens the menu.
+
+<Callout type="info">
+VR controller bindings aren't part of the keyboard rebinding panel — they're driven by the active OpenXR / OpenVR interaction profile for your headset.
+</Callout>
 
 ## Help with Debugging
 
@@ -42,5 +106,5 @@ Let's create a page to cover the available controls in BasisVR
   It stores a mapping of the avatars, worlds, and props currently contained in your library.
 
 <Callout>
-Within the codebase, you can also find there is an `EmbeddedItems` class containing library items that are embedded into the application.   
+Within the codebase, you can also find there is an `EmbeddedItems` class containing library items that are embedded into the application.
 </Callout>

--- a/content/docs/controls/meta.json
+++ b/content/docs/controls/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Controls",
   "icon": "Wrench",
-  "pages": ["index"]
+  "pages": ["index", "full-body-tracking", "hand-tracking", "players-menu", "chatbox"]
 }

--- a/content/docs/controls/players-menu.mdx
+++ b/content/docs/controls/players-menu.mdx
@@ -1,0 +1,52 @@
+---
+title: Players Menu
+description: The per-player panel in the Basis client — mute, volume, block, pin, highlight, direct connections and more.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Overview
+
+Selecting another player in the menu opens their **player panel** — a set of per-player controls that only affect how *you* see and hear that person. Mutes, volume changes and blocks are local to your client; they don't change anything for anyone else in the room.
+
+{/* IMAGE PLACEHOLDER
+    File:  public/img/controls/players-menu.png
+    Show:  the individual player panel open for a selected player, with the per-player controls visible.
+    When ready, replace this comment with:
+    ![The per-player options panel](/img/controls/players-menu.png)
+*/}
+
+## What you can do per player
+
+### Audio
+
+- **Mute / Unmute** — silences that player for you. Your volume setting is remembered, so unmuting restores it.
+- **Volume** — a per-player volume slider from silent up to a boost above normal, with a live level meter so you can see them speaking.
+
+### Visibility and interaction
+
+- **Show / Hide avatar** — hides that player's avatar from your view.
+- **Interactions** — enable or disable interacting with their avatar.
+- **Chat visibility** — show or hide their chat messages for you.
+
+### Block
+
+- **Block / Unblock** — a stronger action that applies both audio and avatar visibility at once, behind a confirmation prompt. Blocking is session-aware, so the other player is told you've blocked them for moderation purposes.
+
+### Find and mark players
+
+- **Highlight** — draws a beacon above the player so you can spot them in a crowd (it turns red if they're blocked).
+- **Pin** — marks a player as a favourite so they're easy to find again later. Pins are saved between sessions.
+
+### Talk privately
+
+- **Private chat** — add a player to a private voice group, or switch to talking to **only** that player.
+- **Direct connection** — request a peer-to-peer connection to a specific player. Once connected, the panel shows the round-trip ping, and you can set a per-player policy to ask, always accept or always decline future requests.
+
+### Moderation
+
+- **Teleport to** — jump to a player's location. This is an admin-only action and only appears if you have the permission for it.
+
+<Callout type="info">
+Most of these settings persist per player, so someone you've muted, blocked or set a custom volume for stays that way the next time you meet them.
+</Callout>

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -70,6 +70,10 @@ If you have the correct Unity version already installed but the "Add Modules" op
 
 ## Acquiring the Basis framework
 
+<Callout type="warn">
+**Install Git first — even if you download the project as a ZIP.** Several of the framework's packages are pulled from Git repositories when Unity first opens the project (for example AudioLink, the Valve OpenXR utilities and RNNoise). If Git isn't installed and on your system `PATH`, those packages fail to resolve and the project opens with compile errors. Install [Git](https://git-scm.com/downloads), restart Unity Hub, then open the project. You can confirm Git is on your `PATH` by running `git --version` in a terminal.
+</Callout>
+
 ### Git
 
 You can either directly [clone](https://docs.github.com/en/repositories/creating-and-managing-repositories/cloning-a-repository) the `developer` or `long-term-support` branches found at https://github.com/BasisVR/Basis or [fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) it to your own local repository, and then open the resulting Unity project on your local computer.

--- a/content/docs/technical/meta.json
+++ b/content/docs/technical/meta.json
@@ -2,6 +2,7 @@
     "title": "Technical",
     "pages": [
         "linux",
-        "limiting-unity-cpu"
+        "limiting-unity-cpu",
+        "network-syncing"
     ]
 }

--- a/content/docs/technical/network-syncing.mdx
+++ b/content/docs/technical/network-syncing.mdx
@@ -1,0 +1,45 @@
+---
+title: Network Syncing
+description: How Basis keeps players in sync — the authoritative server model, what gets replicated, how movement stays smooth, and client/server version compatibility.
+---
+
+import { Callout } from 'fumadocs-ui/components/callout';
+
+## Overview
+
+Basis is **client–server**: every client connects to a server, and the server is the authority that relays state between players. There's no direct mesh of clients by default — your client sends its state to the server, and the server forwards it to the others (with an optional peer-to-peer path for specific cases, see below).
+
+The transport is **LiteNetLib over UDP**, with several delivery guarantees chosen per message type:
+
+- **Unreliable** for high-rate state like avatar pose and voice — the occasional dropped packet is cheaper to skip than to resend, because a newer update is always close behind.
+- **Reliable / ordered** for things that must arrive and must arrive in order, such as ownership changes.
+
+## What gets synced
+
+- **Avatar pose** — your body and bone transforms, streamed continuously so others see you move.
+- **Voice** — spatialised by default, so a player's voice comes from their position in the world. There's also a non-spatialised broadcast path.
+- **Object ownership** — networked props track which player currently owns them, so only one client drives a given object at a time. Ownership transfers are sent reliably and in order.
+
+## Keeping movement smooth
+
+A few things work together so other players look smooth even over an imperfect connection:
+
+- **Interpolation** — remote avatars are interpolated between received updates rather than snapped to each one, and bone rotations are blended frame to frame.
+- **Jitter absorption** — a smoothing filter absorbs small variations in packet timing without distorting the actual motion path.
+- **Distance-based update rate** — the server sends pose updates for nearby players more often than distant ones. As a player gets further away, their update interval grows, which keeps bandwidth and CPU under control in busy instances while keeping close interactions crisp.
+
+<Callout type="info">
+Because update rate scales with distance, someone across a large world updates less often than someone next to you. This is deliberate — it's what lets instances hold a lot of players without flooding everyone's connection.
+</Callout>
+
+## Peer-to-peer connections
+
+Alongside the server relay, two players can establish a **direct peer-to-peer connection** to each other — used for the per-player direct-connect feature in the [players menu](/en/docs/controls/players-menu). The server still mediates everyone else; P2P is an addition for a specific pair, not a replacement for the server.
+
+## Client and server versions must match
+
+The network protocol is **versioned**. When a client connects, the server checks the client's protocol version against its own. If the client is older than the server expects, the server **rejects the connection** with an *"Outdated client version"* reason rather than letting a mismatched client join.
+
+<Callout type="warn">
+If you self-host, keep your server and clients on compatible builds. A client that's behind the server's protocol version is refused at connect time; protocol changes ship by bumping this version, so an out-of-date client or server is the usual cause of a connection that's rejected immediately.
+</Callout>


### PR DESCRIPTION
Adds and expands docs to cover a batch of open documentation-gap issues. Everything here was checked against the current Basis client/server code, and the site builds cleanly (`npm run build`).

**New pages**
- **Full Body Tracking** — tracker calibration, pairing and manual role overrides (#84)
- **Hand Tracking** — OpenXR finger tracking and controller fallback (#93)
- **Players Menu** — the per-player panel: mute, volume, block, pin, direct connect (#92)
- **Chatbox** — text chat, typing indicator and the OSC bridge (#86)
- **Animation Recorder** — recording your local avatar's motion (#118)
- **Network Syncing** — authoritative server model, what's replicated, smoothing, and client/server version compatibility (#64)

**Expanded pages**
- **Settings and Controls** — full default keybinding reference for desktop and VR, plus where to rebind (#55)
- **Getting Started** — note that Git must be installed for package resolution on first open (#119)
- **Face Tracking** — a Basis-side setup overview alongside the existing external guide (#87)

**Images:** pages that would benefit from screenshots carry placeholders marking exactly where each image goes and what it should show — happy to follow up with those (or take community contributions) in a separate PR.

Note on #111: the specific error string reported there doesn't exist in the current code; the real version-mismatch behaviour is an "Outdated client version" rejection, which is documented in the new Network Syncing page instead.